### PR TITLE
PD-232, PD-233

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-router": "^7.3.0",
     "react-router-dom": "^7.3.0",
     "react-toastify": "^11.0.5",
+    "typescript-cookie": "^1.0.6",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       react-toastify:
         specifier: ^11.0.5
         version: 11.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      typescript-cookie:
+        specifier: ^1.0.6
+        version: 1.0.6
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -721,6 +724,9 @@ packages:
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
+  '@types/js-cookie@3.0.6':
+    resolution: {integrity: sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1853,6 +1859,10 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
+  typescript-cookie@1.0.6:
+    resolution: {integrity: sha512-s+BZr7/9BUG6Kg7jGGcOY/4XJcP+iZRFdF3q4FPTfRSP83ivLWF94OcH8PrzGmnS8Ab9qP7ENu/ikLwNFsIafA==}
+    engines: {node: '>=14'}
+
   typescript-eslint@8.26.1:
     resolution: {integrity: sha512-t/oIs9mYyrwZGRpDv3g+3K6nZ5uhKEMt2oNmAPwaY4/ye0+EH4nXIPYNtkYFS6QHm+1DFg34DbglYBz5P9Xysg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2508,6 +2518,8 @@ snapshots:
   '@types/cookie@0.6.0': {}
 
   '@types/estree@1.0.6': {}
+
+  '@types/js-cookie@3.0.6': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -3842,6 +3854,8 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
+
+  typescript-cookie@1.0.6: {}
 
   typescript-eslint@8.26.1(eslint@9.20.0)(typescript@5.7.3):
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import BoardDetail from "./page/board/[boardId]";
 import EditBoard from "./page/board/[boardId]/edit";
 import CreateBoard from "./page/board/create";
 import BoardList from "./page/board/index";
-import Main from "./page/index";
+import Login from "./page/index/login";
 
 import "@fontsource/roboto/300.css";
 import "@fontsource/roboto/400.css";
@@ -15,7 +15,7 @@ const App = () => {
   return (
     <BrowserRouter>
       <Routes>
-        <Route index element={<Main />} />
+        <Route index element={<Login />} />
         <Route path="/board" element={<BoardList />} />
         <Route path="/board/create" element={<CreateBoard />} />
         <Route path="/board/:boardId" element={<BoardDetail />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import BoardDetail from "./page/board/[boardId]";
 import EditBoard from "./page/board/[boardId]/edit";
 import CreateBoard from "./page/board/create";
 import BoardList from "./page/board/index";
+import AcademyList from "./page/academy/index";
 import Login from "./page/index/login";
 
 import "@fontsource/roboto/300.css";
@@ -16,6 +17,7 @@ const App = () => {
     <BrowserRouter>
       <Routes>
         <Route index element={<Login />} />
+        <Route path="/academy" element={<AcademyList />} />
         <Route path="/board" element={<BoardList />} />
         <Route path="/board/create" element={<CreateBoard />} />
         <Route path="/board/:boardId" element={<BoardDetail />} />

--- a/src/api/academy/query.ts
+++ b/src/api/academy/query.ts
@@ -1,0 +1,21 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { academyApi } from "./request";
+
+export const academyQueries = {
+  all: ["academy"],
+  list: () =>
+    queryOptions({
+      queryKey: [...academyQueries.all, "list"],
+      queryFn: () => academyApi.getList(),
+    }),
+//   details: (id: number) => [...academyQueries.all, "detail", id],
+//   detail: (id: number) =>
+//     queryOptions({
+//       queryKey: [...academyQueries.details(id), id],
+//       queryFn: () => {
+//         console.log(id)
+//         return academyQueries.getPost(id)
+//       },
+//     }),
+};

--- a/src/api/academy/request.ts
+++ b/src/api/academy/request.ts
@@ -11,12 +11,8 @@ export const academyApi = {
 
   // 로그인
   getList: async (): Promise<AcademyListItem[]> => {
-    try {
-      return await http.get<AcademyListItem[]>({
-        url: ACADEMY_API.BASE,
-      });
-    } catch (error) {
-      throw new Error("조회 실패");
-    }
+    return await http.get<AcademyListItem[]>({
+      url: ACADEMY_API.BASE,
+    });
   }
 }

--- a/src/api/academy/request.ts
+++ b/src/api/academy/request.ts
@@ -13,7 +13,7 @@ export const academyApi = {
   getList: async (): Promise<Academy[]> => {
     try {
       return await http.get<Academy[]>({
-        url: "http://localhost:8080/api/v1/academies",  // 절대 경로 사용
+        url: ACADEMY_API.BASE,
       });
     } catch (error) {
       throw new Error("조회 실패");

--- a/src/api/academy/request.ts
+++ b/src/api/academy/request.ts
@@ -1,0 +1,22 @@
+import type { Academy } from "../../type/academy";
+import http from "../instance";
+
+// API 엔드포인트
+const ACADEMY_API = {
+  BASE: "/academies",
+};
+
+// API 함수들
+export const academyApi = {
+
+  // 로그인
+  getList: async (): Promise<Academy[]> => {
+    try {
+      return await http.get<Academy[]>({
+        url: "http://localhost:8080/api/v1/academies",  // 절대 경로 사용
+      });
+    } catch (error) {
+      throw new Error("조회 실패");
+    }
+  }
+}

--- a/src/api/academy/request.ts
+++ b/src/api/academy/request.ts
@@ -1,4 +1,4 @@
-import type { Academy } from "../../type/academy";
+import type { AcademyListItem } from "../../type/academy";
 import http from "../instance";
 
 // API 엔드포인트
@@ -10,9 +10,9 @@ const ACADEMY_API = {
 export const academyApi = {
 
   // 로그인
-  getList: async (): Promise<Academy[]> => {
+  getList: async (): Promise<AcademyListItem[]> => {
     try {
-      return await http.get<Academy[]>({
+      return await http.get<AcademyListItem[]>({
         url: ACADEMY_API.BASE,
       });
     } catch (error) {

--- a/src/api/auth/request.ts
+++ b/src/api/auth/request.ts
@@ -16,8 +16,7 @@ export const authApi = {
   ): Promise<SignInResponse> => {
     try {
       const response = await http.post<SignInResponse>({
-        // url: AUTH_API.BASE + AUTH_API.SIGN_IN,
-        url: "http://localhost:8080/api/v1/auth/sign-in",  // 절대 경로 사용
+        url: AUTH_API.BASE + AUTH_API.SIGN_IN,
         data,
       });
       return response;

--- a/src/api/auth/request.ts
+++ b/src/api/auth/request.ts
@@ -1,0 +1,29 @@
+import type { SignInRequest, SignInResponse } from "../../type/auth";
+import http from "../instance";
+
+// API 엔드포인트
+const AUTH_API = {
+  BASE: "/auth",
+  SIGN_IN: "/sign-in",
+};
+
+// API 함수들
+export const authApi = {
+
+  // 로그인
+  signIn: async (
+    data: SignInRequest
+  ): Promise<SignInResponse> => {
+    try {
+      const response = await http.post<SignInResponse>({
+        // url: AUTH_API.BASE + AUTH_API.SIGN_IN,
+        url: "http://localhost:8080/api/v1/auth/sign-in",  // 절대 경로 사용
+        data,
+      });
+      return response;
+    } catch (error) {
+      // TODO : responseCode 분기
+      throw new Error("로그인 실패");
+    }
+  }
+}

--- a/src/api/auth/request.ts
+++ b/src/api/auth/request.ts
@@ -18,6 +18,7 @@ export const authApi = {
       const response = await http.post<SignInResponse>({
         url: AUTH_API.BASE + AUTH_API.SIGN_IN,
         data,
+        useAuth: false,
       });
       return response;
     } catch (error) {

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -153,7 +153,8 @@ class CustomAxios {
   }
 }
 
-const baseURL = `${window.location.origin}/api/`;
+// const baseURL = `${window.location.origin}/api/`;
+const baseURL = `http://localhost:8080/api/v1/`;
 
 const http = new CustomAxios(baseURL);
 

--- a/src/api/response/response-code.ts
+++ b/src/api/response/response-code.ts
@@ -1,4 +1,4 @@
 export enum CommonResponseCode {
-  SUCCESS = "CMN-001",
-  FAILED = "CMN-002",
+  SUCCESS = "CM-001",
+  FAILED = "CM-002",
 }

--- a/src/page/academy/index/index.tsx
+++ b/src/page/academy/index/index.tsx
@@ -1,0 +1,100 @@
+import {
+    Container,
+    Typography,
+    Paper,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    Button,
+    CircularProgress,
+  } from "@mui/material";
+  import { useQuery } from "@tanstack/react-query";
+  import { useEffect } from "react";
+  import { useNavigate } from "react-router-dom";
+  
+  import { academyQueries } from "@/api/academy/query";
+  
+  const AcademyList = () => {
+    const navigate = useNavigate();
+  
+    const { data: academies, isLoading, error } = useQuery(academyQueries.list());
+  
+    useEffect(() => {
+      if (error) {
+        alert("게시글 목록을 불러오는데 실패했습니다.");
+      }
+    }, [error]);
+  
+    const handleCreateClick = () => {
+      navigate("/board/create");
+    };
+  
+    const handleRowClick = (postId: number) => {
+      navigate(`/board/${postId}`);
+    };
+  
+    if (isLoading) {
+      return (
+        <Container sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+          <CircularProgress />
+        </Container>
+      );
+    }
+  
+    if (error) {
+      return (
+        <Container sx={{ mt: 4 }}>
+          <Typography color="error">게시글을 불러오는데 실패했습니다.</Typography>
+        </Container>
+      );
+    }
+  
+    return (
+      <Container maxWidth="lg" sx={{ mt: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          학원
+        </Typography>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleCreateClick}
+          sx={{ mb: 2 }}
+        >
+          글 작성
+        </Button>
+        <TableContainer component={Paper}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>번호</TableCell>
+                <TableCell>제목</TableCell>
+                <TableCell>작성자</TableCell>
+                <TableCell>작성일</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {academies?.map((academies) => (
+                <TableRow
+                  key={academies.id}
+                  hover
+                  onClick={() => handleRowClick(academies.id)}
+                  sx={{ cursor: "pointer" }}
+                >
+                  <TableCell>{academies.name}</TableCell>
+                  <TableCell>{academies.description}</TableCell>
+                  <TableCell>{academies.businessRegistrationNumber}</TableCell>
+                  <TableCell>{academies.locationType}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Container>
+    );
+  };
+  
+  export default AcademyList;
+  

--- a/src/page/academy/index/index.tsx
+++ b/src/page/academy/index/index.tsx
@@ -1,5 +1,6 @@
 import {
     Container,
+    Box,
     Typography,
     Paper,
     Table,
@@ -54,25 +55,30 @@ import {
   
     return (
       <Container maxWidth="lg" sx={{ mt: 4 }}>
-        <Typography variant="h4" component="h1" gutterBottom>
-          학원
-        </Typography>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={handleCreateClick}
-          sx={{ mb: 2 }}
-        >
-          글 작성
-        </Button>
+
+        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 2 }}>
+          <Typography variant="h4" component="h1" gutterBottom>
+            학원
+          </Typography>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleCreateClick}
+          >
+            학원 추가
+          </Button>
+        </Box>
+
         <TableContainer component={Paper}>
           <Table>
             <TableHead>
               <TableRow>
                 <TableCell>번호</TableCell>
-                <TableCell>제목</TableCell>
-                <TableCell>작성자</TableCell>
-                <TableCell>작성일</TableCell>
+                <TableCell>학원명</TableCell>
+                <TableCell>사업자 등록번호</TableCell>
+                <TableCell>대표자명</TableCell>
+                <TableCell>대표자 이메일</TableCell>
+                <TableCell>주소</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -83,10 +89,12 @@ import {
                   onClick={() => handleRowClick(academies.id)}
                   sx={{ cursor: "pointer" }}
                 >
-                  <TableCell>{academies.name}</TableCell>
-                  <TableCell>{academies.description}</TableCell>
+                  <TableCell>{academies.id}</TableCell>
+                  <TableCell>{academies.name} ({academies.nameEn})</TableCell>
                   <TableCell>{academies.businessRegistrationNumber}</TableCell>
-                  <TableCell>{academies.locationType}</TableCell>
+                  <TableCell>{academies.representativeName}</TableCell>
+                  <TableCell>{academies.representativeEmail}</TableCell>
+                  <TableCell>{academies.locationType} / {academies.detailedAddress}</TableCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/src/page/index/index.tsx
+++ b/src/page/index/index.tsx
@@ -1,9 +1,0 @@
-const Main = () => {
-  return (
-    <div>
-      <h1>Main</h1>
-    </div>
-  );
-};
-
-export default Main;

--- a/src/page/index/login.tsx
+++ b/src/page/index/login.tsx
@@ -43,7 +43,7 @@ const Login = () => {
         navigate(`/academy`);
       },
       onError: () => {
-        alert("아이디 비밀번호를 확인해주세요");
+        toast.error("아이디 비밀번호를 확인해주세요");
       },
     });
   };

--- a/src/page/index/login.tsx
+++ b/src/page/index/login.tsx
@@ -13,6 +13,7 @@ import { useNavigate } from "react-router-dom";
 
 import { authApi } from "@/api/auth/request";
 import { SignInRequestSchema, SignInResponse, type SignInRequest } from "@/type/auth";
+import { setCookie } from "typescript-cookie";
 
 const defaultValues: SignInRequest = {
   email: "",
@@ -38,8 +39,8 @@ const Login = () => {
   const onSubmit = async (data: SignInRequest) => {
     requestSignIn.mutate(data, {
       onSuccess: (data: SignInResponse) => {
-        console.log(data.accessToken);
-        // navigate(`/board`);
+        setCookie("Authorization", data.accessToken);
+        navigate(`/academy`);
       },
       onError: () => {
         alert("아이디 비밀번호를 확인해주세요");

--- a/src/page/index/login.tsx
+++ b/src/page/index/login.tsx
@@ -1,0 +1,102 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Container,
+  TextField,
+  Button,
+  Box,
+  Typography,
+  CircularProgress,
+} from "@mui/material";
+import { useMutation } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+
+import { authApi } from "@/api/auth/request";
+import { SignInRequestSchema, SignInResponse, type SignInRequest } from "@/type/auth";
+
+const defaultValues: SignInRequest = {
+  email: "",
+  password: "",
+};
+
+const Login = () => {
+  const navigate = useNavigate();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<SignInRequest>({
+    resolver: zodResolver(SignInRequestSchema),
+    defaultValues,
+  });
+  
+  const requestSignIn = useMutation({
+    mutationFn: authApi.signIn,
+  })
+
+  const onSubmit = async (data: SignInRequest) => {
+    requestSignIn.mutate(data, {
+      onSuccess: (data: SignInResponse) => {
+        console.log(data.accessToken);
+        // navigate(`/board`);
+      },
+      onError: () => {
+        alert("아이디 비밀번호를 확인해주세요");
+      },
+    });
+  };
+
+  return (
+    <Container maxWidth="xs">
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        minHeight="100vh"
+      >
+        <Typography variant="h4" gutterBottom>
+          관리자 페이지
+        </Typography>
+
+        <Box
+          component="form"
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <TextField
+            label="이메일"
+            variant="outlined"
+            fullWidth
+            margin="normal"
+            {...register("email")}
+            error={!!errors.email}
+            helperText={errors.email?.message}
+          />
+          <TextField
+            label="비밀번호"
+            type="password"
+            variant="outlined"
+            fullWidth
+            margin="normal"
+            {...register("password")}
+            error={!!errors.password}
+            helperText={errors.password?.message}
+          />
+          <Button
+            variant="contained"
+            color="primary"
+            fullWidth
+            type="submit"
+            disabled={requestSignIn.isPending}
+            sx={{ mt: 2 }}
+          >
+            {requestSignIn.isPending ? <CircularProgress size={24} /> : "로그인"}
+          </Button>
+        </Box>
+      </Box>
+    </Container>
+  );
+};
+
+export default Login;

--- a/src/type/academy.ts
+++ b/src/type/academy.ts
@@ -1,10 +1,14 @@
 import { z } from "zod";
 
+// 공통 Academy 스키마
 export const AcademySchema = z.object({
   id: z.number(),
-  name: z.string().min(1, "학원 이름을 입력해주세요"),
-  description: z.string().nullable(),
-  businessRegistrationNumber: z.string().nullable(),
+  name: z.string(),
+  nameEn: z.string(),
+  representativeName: z.string(),
+  representativeEmail: z.string().email(),
+  description: z.string().nullable().optional(), // 상세 조회에서만 사용
+  businessRegistrationNumber: z.string(),
   locationType: z.enum([
     "SEOUL",
     "BUSAN",
@@ -24,13 +28,51 @@ export const AcademySchema = z.object({
     "GYEONGNAM",
     "JEJU",
   ]),
-  detailedAddress: z.string().min(1, "상세 주소를 입력해주세요"),
-  forKindergarten: z.boolean(),
-  forElementary: z.boolean(),
-  forMiddleSchool: z.boolean(),
-  forHighSchool: z.boolean(),
-  forAdult: z.boolean(),
-  imageUrls: z.array(z.string().url()),  // URL 형태로 검증
+  detailedAddress: z.string(),
+  byAdmin: z.boolean().optional(), // 목록 조회에서만 사용
+  lat: z.number().optional(), // 상세 조회에서만 사용
+  lng: z.number().optional(), // 상세 조회에서만 사용
+  forKindergarten: z.boolean().optional(), // 상세 조회에서만 사용
+  forElementary: z.boolean().optional(), // 상세 조회에서만 사용
+  forMiddleSchool: z.boolean().optional(), // 상세 조회에서만 사용
+  forHighSchool: z.boolean().optional(), // 상세 조회에서만 사용
+  forAdult: z.boolean().optional(), // 상세 조회에서만 사용
+  imageUrls: z.array(z.string().url()).optional(), // 상세 조회에서만 사용
 });
 
-export type Academy = z.infer<typeof AcademySchema>;
+// 목록 조회 스키마
+export const AcademyListItemSchema = AcademySchema.pick({
+  id: true,
+  name: true,
+  nameEn: true,
+  representativeName: true,
+  representativeEmail: true,
+  businessRegistrationNumber: true,
+  locationType: true,
+  detailedAddress: true,
+  byAdmin: true,
+});
+
+// 상세 조회 스키마
+export const AcademyDetailSchema = AcademySchema.pick({
+  id: true,
+  name: true,
+  nameEn: true,
+  representativeName: true,
+  description: true,
+  businessRegistrationNumber: true,
+  locationType: true,
+  detailedAddress: true,
+  lat: true,
+  lng: true,
+  forKindergarten: true,
+  forElementary: true,
+  forMiddleSchool: true,
+  forHighSchool: true,
+  forAdult: true,
+  imageUrls: true,
+});
+
+// 목록 조회와 상세 조회 타입
+export type AcademyListItem = z.infer<typeof AcademyListItemSchema>;
+export type AcademyDetail = z.infer<typeof AcademyDetailSchema>;

--- a/src/type/academy.ts
+++ b/src/type/academy.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+export const AcademySchema = z.object({
+  id: z.number(),
+  name: z.string().min(1, "학원 이름을 입력해주세요"),
+  description: z.string().nullable(),
+  businessRegistrationNumber: z.string().nullable(),
+  locationType: z.enum([
+    "SEOUL",
+    "BUSAN",
+    "DAEGU",
+    "INCHEON",
+    "GWANGJU",
+    "DAEJEON",
+    "ULSAN",
+    "SEJONG",
+    "GYEONGGI",
+    "GANGWON",
+    "CHUNGBUK",
+    "CHUNGNAM",
+    "JEONBUK",
+    "JEONNAM",
+    "GYEONGBUK",
+    "GYEONGNAM",
+    "JEJU",
+  ]),
+  detailedAddress: z.string().min(1, "상세 주소를 입력해주세요"),
+  forKindergarten: z.boolean(),
+  forElementary: z.boolean(),
+  forMiddleSchool: z.boolean(),
+  forHighSchool: z.boolean(),
+  forAdult: z.boolean(),
+  imageUrls: z.array(z.string().url()),  // URL 형태로 검증
+});
+
+export type Academy = z.infer<typeof AcademySchema>;

--- a/src/type/auth.ts
+++ b/src/type/auth.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const SignInRequestSchema = z.object({
+  email: z.string().min(1, "이메일을 입력해주세요").email("이메일 형식이 아닙니다"),
+  password: z.string().min(1, "비밀번호를 입력해주세요"),
+});
+
+export const SignInResponseSchema = z.object({
+  accessToken: z.string(),
+});
+
+export type SignInRequest = z.infer<typeof SignInRequestSchema>;
+export type SignInResponse = z.infer<typeof SignInResponseSchema>;


### PR DESCRIPTION
### 개요

로그인 페이지 추가 및 API를 연동하고, 간단하게 JWT를 활용한 학원 목록 페이지를 추가했습니다.

### 작업 내용

- `typescript-cookie` 라이브러리 추가
- 로그인 페이지 추가 및 API 연동
- 학원 목록 페이지 추가 및 API 연동(추후 [PD-233](https://plus82.atlassian.net/browse/PD-233)에서 고도화 예정)
- CommonResponseCode 오타 수정
- API 모듈 jwt-token 동적 활용 로직 추가
- 로그인 후 Authorization 쿠키 get/set

### 추가 필요?

- 토큰 만료 시 쿠키삭제 후 redirect (or refresh)
- 토큰 없으면 redirect

### 질문

- [types/js-cookie](https://www.npmjs.com/package/@types/js-cookie) 를 사용하고 싶었는데 잘 안되네요... 비교적 다운로드가 적은 [typescript-cookie](https://www.npmjs.com/package/typescript-cookie) 로 해결하긴 했습니다.


[PD-233]: https://plus82.atlassian.net/browse/PD-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ